### PR TITLE
CPT name missing from custom column actions

### DIFF
--- a/inc/cpt-testimonial.php
+++ b/inc/cpt-testimonial.php
@@ -33,11 +33,11 @@ class EA_Testimonials {
 		add_action( 'template_redirect', array( $this, 'redirect_single'   )    );
 
 		// Column Filters
-		add_filter( 'manage_edit-testimonial_columns', array( $this, 'testimonial_columns' )        );
+		add_filter( 'manage_edit-testimonial_columns',        array( $this, 'testimonial_columns' )        );
 
 		// Column Actions
-		add_action( 'manage_pages_custom_column',      array( $this, 'custom_columns'      ), 10, 2 );
-		add_action( 'manage_posts_custom_column',      array( $this, 'custom_columns'      ), 10, 2 );
+		add_action( 'manage_testimonial_pages_custom_column', array( $this, 'custom_columns'      ), 10, 2 );
+		add_action( 'manage_testimonial_posts_custom_column', array( $this, 'custom_columns'      ), 10, 2 );
 	}
 
 	/**


### PR DESCRIPTION
I always do a find and replace on this sample file when adding new CPTs, and with ‘testimonial’ missing from those actions, I’ve been overlooking the need to change them to be specific to the CPT.   And if you add 4 CPTs, and overlook it all four times, you wind up with this, lol:  http://cl.ly/image/1O0D1O1N3b1u
